### PR TITLE
fix(report): Handle reports with multiple freeze calls

### DIFF
--- a/bloomstack_core/public/js/query_report.js
+++ b/bloomstack_core/public/js/query_report.js
@@ -22,9 +22,7 @@ bloomstack_core.customizations.QueryReport = {
 	},
 	cleanup() {
 		// unfreeze the screen when query is complete
-		if (frappe.dom.freeze_count > 0) {
-			frappe.dom.unfreeze();
-		}
+		while (frappe.dom.freeze_count > 0) frappe.dom.unfreeze();
 	}
 }
 


### PR DESCRIPTION
Some reports stack additional freezes on top of our loader, causing users to not be able to interact with the report once its loaded. This PR handles such cases.