### PR TITLE
fix(core): set issue status to 'replied' when replied on the issue

### DIFF
--- a/bloomstack_core/hook_events/communication.py
+++ b/bloomstack_core/hook_events/communication.py
@@ -1,0 +1,10 @@
+import frappe 
+
+def set_replied(doc, method):
+    issue = frappe.get_doc("Issue", doc.reference_name)
+    if doc.communication_type == "communication":
+        if doc.recipients == issue.raised_by:
+            issue.update({"status": "Replied"}).save()
+
+        elif doc.sender == issue.raised_by:
+            issue.update({"status": "Open"}).save()

--- a/bloomstack_core/hooks.py
+++ b/bloomstack_core/hooks.py
@@ -112,7 +112,10 @@ doc_events = {
 	},
 	"Stock Entry": {
 		"on_submit": "bloomstack_core.compliance.package.create_package"
-	}
+	},
+    "Communication": {
+        "after_insert": "bloomstack_core.hook_events.communication.set_replied"
+    }
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
The issue status is set to "replied" when replied on the issue and puts it back to "open" when the customer replies back.