### PR TITLE
fix: change Insight Engine label to Dashboard

### DIFF
--- a/bloomstack_core/bloomstack_core/page/insight_engine/insight_engine.js
+++ b/bloomstack_core/bloomstack_core/page/insight_engine/insight_engine.js
@@ -3,7 +3,7 @@
 frappe.pages['insight-engine'].on_page_load = function(wrapper) {
 	var page = frappe.ui.make_app_page({
 		parent: wrapper,
-		title: 'Insight Engine',
+		title: 'Dashboard',
 		single_column: true
 	});
 


### PR DESCRIPTION
Desk fix at https://github.com/DigiThinkIT/bloomstack_demo/pull/12.

<hr>

![image](https://user-images.githubusercontent.com/13396535/61727350-d27fd680-ad90-11e9-963b-f3704b9af40c.png)