### PR TITLE
feat: allow setting roles for a user

### DIFF
--- a/bloomstack_core/services/user.py
+++ b/bloomstack_core/services/user.py
@@ -1,0 +1,12 @@
+import json
+
+import frappe
+
+
+@frappe.whitelist()
+def set_roles():
+	"""overrides roles for a user"""
+	data = json.loads(frappe.request.data)
+	user = frappe.get_doc("User", data.get("uid"))
+	user.set("roles", list(set(d for d in user.get("roles") if d.role in data.get("roles"))))
+	user.add_roles(*data.get("roles"))


### PR DESCRIPTION
**Ref:** [TASK-2019-00564](https://digithinkit.global/desk#Form/Task/TASK-2019-00564)

<hr>

**New endpoint:**

- `bloomstack_core.services.user.set_roles`

The endpoint take 2 arguments:

- `uid`: the email ID of the user
- `roles`: list of roles to set (overrides current roles)

Validations:

- Query must be performed either by an Admin or a user with the System Manager role.