### PR TITLE
fix: redirect if user lands on /demo

### DIFF
--- a/bloomstack_core/templates/pages/demo.html
+++ b/bloomstack_core/templates/pages/demo.html
@@ -1,0 +1,3 @@
+<script>
+window.location.href = "/login";
+</script>


### PR DESCRIPTION
**Ref:** [TASK-2019-00135](https://digithinkit.global/desk#Form/Task/TASK-2019-00135)

<hr>

Overrides the demo.html page. This won't mess with sites with an actual demo on them, as the `bloomstack_demo` app has it's own demo.html which will in turn override this as well 🤣 