### PR TITLE
fix: handle empty assignments

### DIFF
--- a/bloomstack_core/analytics/project.py
+++ b/bloomstack_core/analytics/project.py
@@ -16,7 +16,7 @@ def get_project_details():
 
 		total_tasks = frappe.db.count("Task", filters={"project": project.name})
 		closed_tasks = frappe.db.count("Task", filters={"project": project.name, "status": "Completed"})
-		assigned_users = json.loads(project._assign)
+		assigned_users = json.loads(project._assign) if project._assign else []
 
 		for assignee in assigned_users:
 			full_name = frappe.db.get_value("User", assignee, "full_name")


### PR DESCRIPTION
If there's no assignments for a project, the `json.loads` throws an exception.

Required for https://github.com/DigiThinkIT/digithinkit_project_management/pull/46.