### PR TITLE
fix: Item doc_event hooks

### DIFF
--- a/bloomstack_core/hooks.py
+++ b/bloomstack_core/hooks.py
@@ -129,9 +129,6 @@ notification_config = "bloomstack_core.notifications.get_notification_config"
 # Hook on document methods and events
 
 doc_events = {
-	"Item": {
-		"autoname": "bloomstack_core.hook_events.item.autoname"
-	},
 	"Contract": {
 		"validate": "bloomstack_core.hook_events.contract.generate_contract_terms_display",
 		"on_update_after_submit": [


### PR DESCRIPTION
As a User, I want to create item in ITEM MASTER, but Im facing problem,
On all site when person try to create Item gives this error
https://corp.bloomstack.com/desk#Form/Task/TASK-2020-00075
before:
![Screenshot from 2020-02-04 12-33-29](https://user-images.githubusercontent.com/6947417/73737315-65e68b00-4768-11ea-9c90-8cae9590abef.png)


after:
![Peek 2020-02-04 16-08](https://user-images.githubusercontent.com/6947417/73737471-b4942500-4768-11ea-9138-8d78af847b60.gif)




