### PR TITLE
feat: add endpoint to get driver trips

### DIFF
--- a/bloomstack_core/services/drivers.py
+++ b/bloomstack_core/services/drivers.py
@@ -1,0 +1,75 @@
+import frappe
+from bloomstack_core.hook_events.delivery_trip import get_address_display
+from frappe.utils import add_days, getdate, nowdate
+
+API_VERSION = "v1.0"
+
+
+@frappe.whitelist()
+def trips(driver_email):
+	"""
+	Get all trips assigned to the given driver.
+
+	Args:
+		driver_email (str): The email address of the driver
+
+	Returns:
+		dict: The Delivery Trips assigned to the driver, along with customer and item data
+	"""
+
+	trips_data = []
+	driver_trips = frappe.get_all("Delivery Trip", filters=get_filters(driver_email), fields=["name"])
+
+	for trip in driver_trips:
+		trip_doc = frappe.get_doc("Delivery Trip", trip.name)
+		trip_data = build_trip_data(trip_doc)
+		trips_data.append(trip_data)
+
+	return {
+		"version": API_VERSION,
+		"trips": trips_data
+	}
+
+
+def get_filters(email):
+	return {
+		"docstatus": 1,
+		"driver_email": email,
+		"departure_time": ["BETWEEN", [add_days(getdate(nowdate()), -60), getdate(nowdate())]]
+	}
+
+
+def build_item_data(stop):
+	items_data = []
+	dn_doc = frappe.get_doc("Delivery Note", stop.delivery_note)
+	for item in dn_doc.items:
+		items_data.append({
+			"name": item.item_code,
+			"qty": item.qty,
+			"unitPrice": item.rate
+		})
+	return items_data
+
+
+def build_stop_data(trip):
+	stops_data = []
+	for stop in trip.delivery_stops:
+		stops_data.append({
+			"name": stop.name,
+			"address": get_address_display(stop.address),
+			"amountToCollect": stop.grand_total,
+			"deliveryNote": stop.delivery_note,
+			"customerPhoneNumber": frappe.db.get_value("Address", stop.address, "phone"),
+			"salesInvoice": stop.sales_invoice,
+			"items": build_item_data(stop)
+		})
+	return stops_data
+
+
+def build_trip_data(trip):
+	return {
+		"name": trip.name,
+		"vehicle": trip.vehicle,
+		"company": trip.company,
+		"stops": build_stop_data(trip)
+	}

--- a/bloomstack_core/services/payments.py
+++ b/bloomstack_core/services/payments.py
@@ -4,7 +4,7 @@ from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_return
 
 
 @frappe.whitelist()
-def make_payment(amount, delivery_note, sales_invoice=None, returned_items=None):
+def collect(amount, delivery_note, sales_invoice=None, returned_items=None):
 	"""
 	Make a Payment Entry for the received amount against a delivery.
 


### PR DESCRIPTION
**Changes:**

- Added endpoint for fetching driver trips
  - `GET /api/method/bloomstack_core.services.drivers.trips`
  - Accepts:
    - `driver_email` - email address of the driver
  - Returns:
    - `trips` - all trips assigned to the driver, with customer and stop data

```json
{
  "version": "v1.0",
  "trips": [
    {
      "name": "TOUR-00057",
      "vehicle": "0TFE 96",
      "company": "VapeCo",
      "stops": [
        {
          "name": "208ed46fce",
          "address": "1525, East Saint Gertrude Place<br>\nSanta Ana, California",
          "amountToCollect": 1773.2,
          "deliveryNote": "DN-00178",
          "customerPhoneNumber": "9495729635",
          "salesInvoice": null,
          "items": [
            {
              "name": "VC-CB-CCB-0001",
              "qty": 100.0,
              "unitPrice": 14.3
            }
          ]
        }
      ]
    }
  ]
}
```

- Renamed endpoint for collecting payments
  - `POST /api/method/bloomstack_core.services.payments.collect`
  - TODO: set signature in Delivery Note
