### PR TITLE
fix: driver collection shows all collection info with no filters

### DIFF
--- a/bloomstack_core/bloomstack_core/report/driver_collection/driver_collection.py
+++ b/bloomstack_core/bloomstack_core/report/driver_collection/driver_collection.py
@@ -25,7 +25,7 @@ def get_collections(date_range, driver, show_individual_stops=False):
 		"docstatus": 1
 	}
 	if driver:
-		filters["driver"]: driver
+		filters["driver"] = driver
 
 	delivery_trips = frappe.get_all("Delivery Trip", filters=filters)
 


### PR DESCRIPTION
task:- https://corp.bloomstack.com/desk#Form/Task/TASK-2020-00137
Before:
![Driver_Collection_Task](https://user-images.githubusercontent.com/58166671/75420512-2b829f00-595e-11ea-88c9-93a428a1d354.gif)

After:
![driver_collection_fix](https://user-images.githubusercontent.com/58166671/75419932-e4e07500-595c-11ea-92a4-db304ca0cc8b.gif)
