### PR TITLE
fix: priority removed from portal

### DIFF
--- a/bloomstack_core/bloomstack_core/web_form/issues/issues.json
+++ b/bloomstack_core/bloomstack_core/web_form/issues/issues.json
@@ -19,7 +19,7 @@
  "is_standard": 1,
  "login_required": 1,
  "max_attachment_size": 0,
- "modified": "2020-02-25 00:07:03.082418",
+ "modified": "2020-02-27 21:27:44.004649",
  "modified_by": "Administrator",
  "module": "Bloomstack Core",
  "name": "issues",
@@ -47,20 +47,6 @@
    "options": "Open\nReplied\nHold\nClosed",
    "read_only": 1,
    "reqd": 0,
-   "show_in_filter": 0
-  },
-  {
-   "allow_read_on_all_link_options": 0,
-   "default": "Medium",
-   "fieldname": "priority",
-   "fieldtype": "Link",
-   "hidden": 0,
-   "label": "Priority",
-   "max_length": 0,
-   "max_value": 0,
-   "options": "Issue Priority",
-   "read_only": 0,
-   "reqd": 1,
    "show_in_filter": 0
   },
   {


### PR DESCRIPTION
**Task**: Hide priority from the user's end on the support portal.

**Screenshots**:
**While creating a new issue**:
![Screenshot 2020-02-28 at 11 01 15 AM](https://user-images.githubusercontent.com/49683121/75513232-3b5fb900-5a1a-11ea-8913-34fa4e87345e.png)

**For existing issue**:
![Screenshot 2020-02-28 at 11 01 12 AM](https://user-images.githubusercontent.com/49683121/75513274-6b0ec100-5a1a-11ea-8f96-0c58ab1460b4.png)



