### PR TITLE
fix: fetch package tags from selected batch

### DIFF
--- a/bloomstack_core/hooks.py
+++ b/bloomstack_core/hooks.py
@@ -73,6 +73,7 @@ doctype_js = {
 	"Packing Slip": "public/js/packing_slip.js",
 	"Quotation": "public/js/quotation.js",
 	"Sales Order": "public/js/sales_order.js",
+	"Stock Entry": "public/js/stock_entry.js",
 	"Supplier": "public/js/supplier.js",
 	"User": "public/js/user.js",
 	"Work Order": "public/js/work_order.js"

--- a/bloomstack_core/public/js/stock_entry.js
+++ b/bloomstack_core/public/js/stock_entry.js
@@ -1,0 +1,20 @@
+/* global frappe, erpnext, _ */
+
+frappe.ui.form.on('Stock Entry Detail', {
+	batch_no: (frm, cdt, cdn) => {
+		const row = frm.selected_doc;
+
+		// set package tag from the selected batch, even if empty
+		if (row.batch_no) {
+			frappe.db.get_value("Batch", row.batch_no, "package_tag", (r) => {
+				frappe.model.set_value(cdt, cdn, "package_tag", r.package_tag);
+			})
+		}
+
+		// toggle read-only on package tag field if batch is selected
+		let grid_row = frm.open_grid_row() || frm.get_field(row.parentfield).grid.get_row(cdn);
+		if (grid_row) {
+			grid_row.toggle_editable("package_tag", !row.batch_no);
+		}
+	}
+});


### PR DESCRIPTION
**Changes:**

- If a batch is selected in a Stock Entry, pull the package tag value from the batch, even if empty
- Selecting a batch makes the package tag field read-only, to avoid mismatched recording