### PR TITLE
fix: fixed css to style the tables only for WebForms

### DIFF
--- a/bloomstack_core/public/css/webform.css
+++ b/bloomstack_core/public/css/webform.css
@@ -88,5 +88,6 @@ div[data-doctype="Web Form"] table tr input[type="checkbox"]:checked:after {
   border-radius: 0.25rem;
   background: #8e8e8e;
   color: #fff;
+  cursor: pointer;
   text-transform: uppercase;
 }


### PR DESCRIPTION
**Description:**
This is a fix PR, because of the previous PR https://github.com/DigiThinkIT/bloomstack_core/pull/154, the styling on every table was changing, so modified the CSS to apply only to webform listing.