### PR TITLE
fix: update Package Tag in Sales Order when a Pick List is submitted …

### DIFF
--- a/bloomstack_core/hook_events/pick_list.py
+++ b/bloomstack_core/hook_events/pick_list.py
@@ -1,0 +1,17 @@
+import frappe
+
+
+def update_order_package_tag(pick_list, method):
+	package_tags = [item.package_tag for item in pick_list.locations if item.package_tag]
+	if not package_tags:
+		return
+
+	for item in pick_list.locations:
+		if not item.package_tag:
+			continue
+
+		if item.sales_order_item:
+			if method == "on_submit":
+				frappe.db.set_value("Sales Order Item", item.sales_order_item, "package_tag", item.package_tag)
+			elif method == "on_cancel":
+				frappe.db.set_value("Sales Order Item", item.sales_order_item, "package_tag", "")

--- a/bloomstack_core/hooks.py
+++ b/bloomstack_core/hooks.py
@@ -150,9 +150,6 @@ notification_config = "bloomstack_core.notifications.get_notification_config"
 # Hook on document methods and events
 
 doc_events = {
-	"Item": {
-		"autoname": "bloomstack_core.hook_events.item.autoname"
-	},
 	"Contract": {
 		"validate": "bloomstack_core.hook_events.contract.generate_contract_terms_display",
 		"on_update_after_submit": [
@@ -183,8 +180,15 @@ doc_events = {
 	"Employee": {
 		"validate": "bloomstack_core.hook_events.employee.update_driver_employee"
 	},
+	"Item": {
+		"autoname": "bloomstack_core.hook_events.item.autoname"
+	},
 	"Packing Slip": {
 		"on_submit": "bloomstack_core.hook_events.packing_slip.create_stock_entry"
+	},
+	"Pick List": {
+		"on_submit": "bloomstack_core.hook_events.pick_list.update_order_package_tag",
+		"on_cancel": "bloomstack_core.hook_events.pick_list.update_order_package_tag"
 	},
 	"Purchase Receipt": {
 		"on_submit": "bloomstack_core.hook_events.purchase_receipt.set_package_tags"


### PR DESCRIPTION
…/ cancelled

<hr>

**Submit:**

![pick-list-submit-set-package-tag](https://user-images.githubusercontent.com/13396535/82311474-60dddc80-99e3-11ea-87e8-2c2afc8f81d3.gif)

**Cancel:**

![pick-list-submit-remove-package-tag](https://user-images.githubusercontent.com/13396535/82311468-5f141900-99e3-11ea-9909-2274435924c2.gif)