### PR TITLE
feat(order-desk): Add save to draft on order desk

### DIFF
--- a/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
+++ b/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
@@ -176,7 +176,17 @@ erpnext.pos.OrderDesk = class OrderDesk {
 							},
 							() => {}
 							);
-					}}
+					}},
+				reset: (sales_order) =>{
+					this.frm.doc = sales_order;
+					cur_frm.doc = sales_order;
+					// this.order_type_field.set_value(sales_order.order_type);
+					// this.customer_field.set_value(sales_order.customer);
+					// this.delivery_date = sales_order.delivery_date;
+					this.frm.doc.items.forEach(item => {
+						this.update_cart_data(item)
+					})
+				}
 				}
 			});
 	}
@@ -613,6 +623,29 @@ class OrderDeskItems {
 				get_query: () => {
 					return {
 						query: 'bloomstack_core.bloomstack_core.page.order_desk.order_desk.item_group_query'
+					};
+				}
+			},
+			parent: this.wrapper.find('.item-group-field'),
+			render_input: true
+		});
+
+		this.selected_sales_order = frappe.ui.form.make_control({
+			df: {
+				fieldtype: 'Link',
+				label: 'Sales Order',
+				options: 'Sales Order',
+				default: 'New',
+				onchange: (e) => {
+					if(this.selected_sales_order.value){
+						frappe.db.get_doc('Sales Order', this.selected_sales_order.value).then(sales_order => {
+							this.events.reset(sales_order)
+						});
+					}
+				},
+				get_query: () => {
+					return {
+						query: 'bloomstack_core.bloomstack_core.page.order_desk.order_desk.get_sales_order'
 					};
 				}
 			},

--- a/bloomstack_core/bloomstack_core/page/order_desk/order_desk.py
+++ b/bloomstack_core/bloomstack_core/page/order_desk/order_desk.py
@@ -145,3 +145,9 @@ def item_group_query(doctype, txt, searchfield, start, page_len, filters):
 			where (name like %(txt)s) limit {start}, {page_len}"""
 		.format(start=start, page_len= page_len),
 			{'txt': '%%%s%%' % txt})
+
+def get_sales_order(doctype, txt, searchfield, start, page_len, filters):
+	return frappe.db.sql(""" select distinct name from `tabSales Order`
+			where (name like %(txt)s) and (docstatus = 0) limit {start}, {page_len}"""
+		.format(start=start, page_len= page_len),
+			{'txt': '%%%s%%' % txt})


### PR DESCRIPTION
Reference task.
- https://bloomstack.com/desk#Form/Task/TASK-2020-00673
- https://bloomstack.com/desk#Form/Task/TASK-2020-00672 

1. Add "Save as draft" button before/after "Order" Button.
2. Select draft orders filtered by customer and order type if any available. Or default to "New Order" otherwise.

![Screenshot from 2020-05-21 12-25-43](https://user-images.githubusercontent.com/43948551/82534580-feabe580-9b62-11ea-94ce-cd66ae348ce0.png)
