### PR TITLE
fix: handle scenario where batches are auto-created

### DIFF
--- a/bloomstack_core/hook_events/purchase_receipt.py
+++ b/bloomstack_core/hook_events/purchase_receipt.py
@@ -7,6 +7,8 @@ def update_package_tags(pr, method):
 			if method == "on_submit":
 				frappe.db.set_value("Package Tag", item.package_tag, "item_code", item.item_code)
 				frappe.db.set_value("Package Tag", item.package_tag, "batch_no", item.batch_no)
-			elif method == "on_cancel":
+			elif method == "before_cancel":
 				frappe.db.set_value("Package Tag", item.package_tag, "item_code", None)
+				frappe.db.set_value("Package Tag", item.package_tag, "item_name", None)
+				frappe.db.set_value("Package Tag", item.package_tag, "item_group", None)
 				frappe.db.set_value("Package Tag", item.package_tag, "batch_no", None)

--- a/bloomstack_core/hooks.py
+++ b/bloomstack_core/hooks.py
@@ -202,7 +202,9 @@ doc_events = {
 	},
 	"Purchase Receipt": {
 		"on_submit": "bloomstack_core.hook_events.purchase_receipt.update_package_tags",
-		"on_cancel": "bloomstack_core.hook_events.purchase_receipt.update_package_tags"
+		# ERPNext tries to delete auto-created batches on cancel, so removing the link
+		# from Package Tag before the on_cancel hook runs
+		"before_cancel": "bloomstack_core.hook_events.purchase_receipt.update_package_tags"
 	},
 	"Sales Invoice": {
 		"before_update_after_submit": "bloomstack_core.hook_events.sales_invoice.set_invoice_status"


### PR DESCRIPTION
**Ref:** [TASK-2020-00753](https://bloomstack.com/desk#Form/Task/TASK-2020-00753)

<hr>

**Problem:** On cancel of a Purchase Receipt, it would try to delete auto-created Batches (if auto-creation is set up for the Item), which gets linked with the Package Tag.

**Solution:** Before the Purchase Receipt's cancel hook is called, unlink the auto-created Batch with the Package Tag