### PR TITLE
fix: only set package tag in Sales Order item if none are found

### DIFF
--- a/bloomstack_core/hook_events/pick_list.py
+++ b/bloomstack_core/hook_events/pick_list.py
@@ -11,10 +11,14 @@ def update_order_package_tag(pick_list, method):
 			continue
 
 		if item.sales_order_item:
+			existing_package_tag = frappe.db.get_value("Sales Order Item", item.sales_order_item, "package_tag")
+
 			if method == "on_submit":
-				frappe.db.set_value("Sales Order Item", item.sales_order_item, "package_tag", item.package_tag)
+				if not existing_package_tag:
+					frappe.db.set_value("Sales Order Item", item.sales_order_item, "package_tag", item.package_tag)
 			elif method == "on_cancel":
-				frappe.db.set_value("Sales Order Item", item.sales_order_item, "package_tag", "")
+				if existing_package_tag:
+					frappe.db.set_value("Sales Order Item", item.sales_order_item, "package_tag", None)
 
 
 def update_package_tag(pick_list, method):


### PR DESCRIPTION
**Problem:**

If a different Package Tag was selected in the Pick List than the one from the Sales Order, it would override it