### PR TITLE
Fixes Admin & Guest users from being pushed to Bloomtrace

### DIFF
--- a/bloomstack_core/hook_events/user.py
+++ b/bloomstack_core/hook_events/user.py
@@ -7,13 +7,14 @@ from __future__ import unicode_literals
 import frappe
 
 def update_bloomtrace_user(user, method):
-	if frappe.get_conf().enable_bloomtrace and user.user_type == "System User":
-		integration_request = frappe.new_doc("Integration Request")
-		integration_request.update({
-			"integration_type": "Remote",
-			"integration_request_service": "BloomTrace",
-			"status": "Queued",
-			"reference_doctype": "User",
-			"reference_docname": user.name
-		})
-		integration_request.save(ignore_permissions=True)
+	if frappe.get_conf().enable_bloomtrace:
+		if user.user_type == "System User" and user.name not in ["Administrator", "Guest"]:
+			integration_request = frappe.new_doc("Integration Request")
+			integration_request.update({
+				"integration_type": "Remote",
+				"integration_request_service": "BloomTrace",
+				"status": "Queued",
+				"reference_doctype": "User",
+				"reference_docname": user.name
+			})
+			integration_request.save(ignore_permissions=True)


### PR DESCRIPTION
[fix] Disabled creation of integration requests for Bloomtrace for Admin & Guest User accounts