### PR TITLE
fix: set delivey date from parent to child table

### DIFF
--- a/bloomstack_core/public/js/sales_order.js
+++ b/bloomstack_core/public/js/sales_order.js
@@ -31,5 +31,12 @@ frappe.ui.form.on('Sales Order', {
 			indicator: 'green',
 			message: __(`${percentage_discount}% discount applied`)
 		});
+	},
+
+	delivery_date: function(frm) {
+		$.each(frm.doc.items || [], function(i, d) {
+			d.delivery_date = frm.doc.delivery_date;
+		});
+		refresh_field("items");
 	}
 });


### PR DESCRIPTION
Task ID: https://bloomstack.com/desk#Form/Task/TASK-2020-01174
1. If Expected delivery date change it will update all child table delivery date.
2. removed max delivery date auto set to expected delivery date

![Peek 2020-07-17 12-44](https://user-images.githubusercontent.com/6947417/87759340-ca376b80-c82b-11ea-9583-0f0bf378eabe.gif)
