### PR TITLE
fix: add fallback incase the api receives no item qty

### DIFF
--- a/bloomstack_core/services/payments.py
+++ b/bloomstack_core/services/payments.py
@@ -92,7 +92,7 @@ def make_return_delivery(delivery_note, returned_items):
 			if not returned_item:
 				item.qty = 0
 			else:
-				item.qty = -(returned_item.get("qty") or item.qty or 0)
+				item.qty = -(returned_item.get("qty") or item.qty) or 0
 				item.reason_for_return = returned_item.get("reason")
 
 		return_delivery.save()


### PR DESCRIPTION
**Ref:** https://bloomstack.com/desk#Form/Task/TASK-2020-01104

<hr>

**Request**

```http
amount: 145
delivery_note: DN-00990
sales_invoice: ACC-SINV-2020-03585
returned_items: [{"reason":"bad ","item_code":"VC-VC-SVK-0002"}]
```

**Response**

```python
Traceback (most recent call last):
 File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 64, in application
  response = frappe.api.handle()
 File "/home/frappe/frappe-bench/apps/frappe/frappe/api.py", line 59, in handle
  return frappe.handler.handle()
 File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 24, in handle
  data = execute_cmd(cmd)
 File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 63, in execute_cmd
  return frappe.call(method, **frappe.form_dict)
 File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1054, in call
  return fn(*args, **newargs)
 File "/home/frappe/frappe-bench/apps/bloomstack_core/bloomstack_core/services/payments.py", line 54, in collect
  return_delivery_id = make_return_delivery(delivery_note, returned_items)
 File "/home/frappe/frappe-bench/apps/bloomstack_core/bloomstack_core/services/payments.py", line 96, in make_return_delivery
  item.qty = -returned_item.get("qty") or -item.qty
TypeError: bad operand type for unary -: 'NoneType'
```