### PR TITLE
feat(order-desk): added delivery days validation for customer

### DIFF
--- a/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
+++ b/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
@@ -110,21 +110,21 @@ erpnext.pos.OrderDesk = class OrderDesk {
 					this.submit_sales_order()
 				},
 				on_delivery_date_change: (delivery_date) => {
-					this.delivery_date = delivery_date;
-					if (this.frm.doc.customer) {
-						frappe.db.get_value("Customer", { "name" : this.frm.doc.customer}, "delivery_days", (r) => {
-							if (r.delivery_days) {
-								let day = moment(delivery_date).format('dddd');
-								let weekdays = JSON.parse(r.delivery_days);
-								if(!weekdays.includes(day)){
-									frappe.msgprint(__("This order is set to be delivered on a '{0}', but {1} only accepts deliveries on {2}", [day, this.frm.doc.customer, weekdays]));
-								}
-							}
-						})
-					}
-					else if(!this.frm.doc.customer){
+					if (!this.frm.doc.customer) {
 						frappe.throw(__('Please select a customer'));
 					}
+
+					this.delivery_date = delivery_date;
+					frappe.db.get_value("Customer", { "name": this.frm.doc.customer }, "delivery_days", (r) => {
+						if (r.delivery_days) {
+							let day = moment(delivery_date).format('dddd');
+							let weekdays = JSON.parse(r.delivery_days);
+							if (!weekdays.includes(day)) {
+								frappe.msgprint(__("This order is set to be delivered on a '{0}', but {1} only accepts deliveries on {2}",
+									[day, this.frm.doc.customer, weekdays]));
+							}
+						}
+					})
 				},
 				on_delivery_window_change: (type, time) => {
 					if (type == "start") {
@@ -1097,7 +1097,8 @@ class SalesOrderCart {
 			parent: this.wrapper.find('.customer-field'),
 			render_input: true
 		});
-		if(this.frm.doc.delivery_date){
+
+		if (this.frm.doc.delivery_date) {
 			this.delivery_date_field.set_value(this.frm.doc.delivery_date);
 		}
 	}


### PR DESCRIPTION
Requires https://github.com/DigiThinkIT/erpnext/pull/488.

<hr>

[Task](https://bloomstack.com/desk#Form/Task/TASK-2020-01316)

Order Desk
- [x] When a user selects a delivery date, validate its day against the selected days for the customer
- [x] If no days are selected for the customer, assume all days are valid, and let the user proceed
- [x] If the selected day is not valid, show a warning to let the user know they've selected the wrong day, and let the user proceed
