### PR TITLE
Added a config to disable user sync between Bloomstack and Bloomtrace

### DIFF
--- a/bloomstack_core/hook_events/user.py
+++ b/bloomstack_core/hook_events/user.py
@@ -20,7 +20,7 @@ def validate_if_bloomstack_user(user, method):
 
 
 def update_bloomtrace_user(user, method):
-	if not frappe.get_conf().developer_mode and not user.is_new():
+	if not (frappe.get_conf().developer_mode and frappe.get_conf().disable_user_sync and user.is_new()):
 		if user.user_type == "System User" and user.name not in ["Administrator", "Guest"] and not user.works_with_bloomstack:
 			make_integration_request(user.doctype, user.name)
 


### PR DESCRIPTION
[Fix] Added a check to see if disable_user_sync is set in site config and not make integration requests to sync Users with bloomtrace if set