### PR TITLE
fix: desk logo is now bloomstack logo

### DIFF
--- a/bloomstack_core/hooks.py
+++ b/bloomstack_core/hooks.py
@@ -10,6 +10,7 @@ app_icon = "octicon octicon-gear"
 app_color = "light green"
 app_email = "developers@bloomstack.com"
 app_license = "MIT"
+app_logo_url = '/assets/bloomstack_core/images/icon.png'
 
 
 # Set setup defaults


### PR DESCRIPTION
**Task Link:** https://bloomstack.com/desk#Form/Task/TASK-2020-01835

**Screenshot:**
![screenshot-localhost_8005-2020 09 03-16_05_09](https://user-images.githubusercontent.com/45919049/92104683-464b3a00-edff-11ea-8fb3-98bdb6ac6f9e.png)
