### PR TITLE
feat: pop msg order desk

### DIFF
--- a/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
+++ b/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
@@ -460,6 +460,12 @@ erpnext.pos.OrderDesk = class OrderDesk {
 					this.set_form_action();
 					this.set_primary_action_in_modal();
 				}
+				frappe.confirm('Want to create New order',
+					() => {
+						window.location.reload();
+					}, () => {
+						frappe.set_route("Form", this.frm.doc.doctype, this.frm.doc.name);
+				})
 			});
 	}
 


### PR DESCRIPTION
**Task Link :** https://app.asana.com/0/1194641031921089/1191664192477905/f

**Description:** Reset Order desk fields after Placing an order: Added a popup msg which consist of two button ,one button which route to form view and second  button refresh the message so that issuer can make new order
 
**Screenshot:**

- Pop Up Message after placing Order

![Screenshot from 2020-10-01 15-08-50](https://user-images.githubusercontent.com/51395568/94793483-26a43300-03f8-11eb-91db-b99c92b5a405.png)

- When user Press No
![Screenshot from 2020-10-01 15-14-11](https://user-images.githubusercontent.com/51395568/94793898-cc57a200-03f8-11eb-90ef-64539bd5c4cf.png)

- When user press Yes (window refresh for new order)


