### PR TITLE
feat: order desk pop message

### DIFF
--- a/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
+++ b/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
@@ -471,7 +471,6 @@ erpnext.pos.OrderDesk = class OrderDesk {
 					primary_action_label: "Yes",
 					primary_action() {
 						window.location.reload();
-						dialog.hide();
 					},
 					secondary_action_label: "No",
 					secondary_action() {


### PR DESCRIPTION
**Task Link :** https://app.asana.com/0/1194641031921089/1191664192477905/f

**Description:** Reset Order desk fields after Placing an order: Added a popup msg which consist of two button ,one button which route to form view and second  button refresh the message so that issuer can make new order
 
**Screenshot:**

- Pop Up Message after placing Order
![Screenshot from 2020-10-05 15-48-57](https://user-images.githubusercontent.com/51395568/95068030-5453e980-0722-11eb-8fb9-da144b97ce34.png)



- When user Press close
![Screenshot from 2020-10-01 15-14-11](https://user-images.githubusercontent.com/51395568/94793898-cc57a200-03f8-11eb-90ef-64539bd5c4cf.png)

- When user press Yes (window refresh for new order)


