### PR TITLE
fix: build files in assets folder

### DIFF
--- a/bloomstack_core/bloomstack_core/page/license_search/license_search.js
+++ b/bloomstack_core/bloomstack_core/page/license_search/license_search.js
@@ -5,9 +5,8 @@ frappe.pages['license-search'].on_page_load = function(wrapper) {
 frappe.views.LicenseSearchFactory = class LicenseSearchFactory extends frappe.views.Factory {
 	make(page_name) {
 		const assets = [
-			'assets/bloomstack_core/js/min/license_search.min.js',
-			'assets/bloomstack_core/css/license_search.css',
-			'assets/bloomstack_core/css/nprogress.css'
+			'/assets/js/license_search.min.js',
+			'/assets/css/license_search.min.css'
 		];
 
 		frappe.require(assets, () => {

--- a/bloomstack_core/public/build.json
+++ b/bloomstack_core/public/build.json
@@ -8,8 +8,12 @@
 		"public/js/templates/contact_list.html",
 		"public/js/address_and_contact.js"
 	],
-	"bloomstack_core/js/min/license_search.min.js": [
+	"js/license_search.min.js": [
 		"public/js/bloomstack_core/license_search/license_search.js"
+	],
+	"css/license_search.min.css": [
+		"public/css/nprogress.css",
+		"public/css/license_search.css"
 	],
 	"css/reports.min.css": [
 		"public/css/reports.css"


### PR DESCRIPTION
- The rollup path for license search page was directed to js folder in the app and not the sites/assets folder which leads to git tracking the min.css and min.js files which shouldnt be the case.
![image](https://user-images.githubusercontent.com/7310479/95331416-979b8d00-08c7-11eb-94c1-fa1fa5b4fc26.png)
- This bug fix, corrects the path in which the minified files should be made.
