### PR TITLE
feat: allow auto generating Sales Invoice for Companion app

### DIFF
--- a/bloomstack_core/hook_events/delivery_note.py
+++ b/bloomstack_core/hook_events/delivery_note.py
@@ -11,13 +11,15 @@ from bloomstack_core.bloomtrace import get_bloomtrace_client
 def link_invoice_against_delivery_note(delivery_note, method):
 	for item in delivery_note.items:
 		if item.against_sales_order and not item.against_sales_invoice:
-			sales_invoice = frappe.get_all("Sales Invoice Item",
+			sales_invoice_details = frappe.get_all("Sales Invoice Item",
 				filters={"docstatus": 1, "sales_order": item.against_sales_order},
-				fields=["distinct(parent)"])
+				fields=["distinct(parent)", "delivery_note"])
 
-			if sales_invoice and len(sales_invoice) == 1:
-				item.against_sales_invoice = sales_invoice[0].parent
-
+			if sales_invoice_details and len(sales_invoice_details) == 1:
+				if sales_invoice_details[0].delivery_note:
+					continue
+				frappe.db.set_value("Delivery Note Item", item.name,
+				    "against_sales_invoice", sales_invoice_details[0].parent)
 
 def execute_bloomtrace_integration_request():
 	frappe_client = get_bloomtrace_client()

--- a/bloomstack_core/hooks.py
+++ b/bloomstack_core/hooks.py
@@ -185,7 +185,8 @@ doc_events = {
 		"before_submit": [
 			"bloomstack_core.hook_events.delivery_note.link_invoice_against_delivery_note",
 			"bloomstack_core.compliance.package.create_package_from_delivery"
-		]
+		],
+		"on_update_after_submit": "bloomstack_core.hook_events.delivery_note.link_invoice_against_delivery_note"
 	},
 	"Package Tag": {
 		"validate": "bloomstack_core.hook_events.utils.create_integration_request",

--- a/bloomstack_core/services/payments.py
+++ b/bloomstack_core/services/payments.py
@@ -34,6 +34,10 @@ def collect(amount, delivery_note, sales_invoice=None, returned_items=None):
 				"return_delivery_id": "DN-0001"
 			}
 	"""
+	# set Delivery note as "Delivered"
+	delivery_note_doc = frappe.get_doc("Delivery Note", delivery_note)
+	delivery_note_doc.delivered = 1
+	delivery_note_doc.save()
 
 	# generate a payment entry for the delivered items
 	if not sales_invoice:
@@ -43,6 +47,14 @@ def collect(amount, delivery_note, sales_invoice=None, returned_items=None):
 
 		if invoices:
 			sales_invoice = invoices[0].against_sales_invoice
+
+	if not sales_invoice: # check for reverse linking
+		invoices = frappe.get_all("Sales Invoice Item",
+			filters={"docstatus": 1, "delivery_note": delivery_note},
+			fields=["distinct(parent)"])
+
+		if invoices:
+			sales_invoice = invoices[0].parent
 
 	if not sales_invoice:
 		frappe.throw(_("No invoice found to make payment against"))


### PR DESCRIPTION
[TASK](https://app.asana.com/0/1197190500424417/1193908647575441)

If the Account Settings for Auto generating Sales Invoice is set on "Delivered". then this access point('collect') will create new Sales Invoice for respective Delivery Note.
To ignore Circular linking on Delivery Note and Sales Invoice, the hook_events for delivery_note is also updated