### PR TITLE
feat:pop up message order desk

### DIFF
--- a/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
+++ b/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
@@ -469,7 +469,7 @@ erpnext.pos.OrderDesk = class OrderDesk {
 					this.set_primary_action_in_modal();
 				}
 				let dialog = new frappe.ui.Dialog({
-					title: (`Your order ${docname} has been created`),
+					title: __("Your order {0} has been created", [docname]),
 					fields: [
 						{ fieldtype: "HTML", options: `<p>Do you want to create a new order?</p>` }
 					],

--- a/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
+++ b/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
@@ -1140,10 +1140,9 @@ class SalesOrderCart {
 				fieldname: 'delivery_date',
 				reqd: 1,
 				onchange: () => {
-					if(this.delivery_date_field.get_value()){
+					if (this.delivery_date_field.get_value()) {
 						this.events.on_delivery_date_change(this.delivery_date_field.get_value());
 					}
-					
 				}
 			},
 			parent: this.wrapper.find('.customer-field'),


### PR DESCRIPTION
**Task Link :** https://app.asana.com/0/1194641031921089/1191664192477905/f

**Description:** Reset Order desk fields after Placing an order: Added a popup msg which consist of two button ,one button which route to form view and second  button refresh the message so that issuer can make new order
 
**Screenshot:**

- Pop Up Message after placing Order
![Screenshot from 2020-10-05 15-48-57](https://user-images.githubusercontent.com/51395568/95068030-5453e980-0722-11eb-8fb9-da144b97ce34.png)



- When user Press close
![Screenshot from 2020-10-01 15-14-11](https://user-images.githubusercontent.com/51395568/94793898-cc57a200-03f8-11eb-90ef-64539bd5c4cf.png)

- When user press Yes (window refresh for new order)


