### PR TITLE
fix:order desk pop message tile change

### DIFF
--- a/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
+++ b/bloomstack_core/bloomstack_core/page/order_desk/order_desk.js
@@ -472,7 +472,7 @@ erpnext.pos.OrderDesk = class OrderDesk {
 					this.set_primary_action_in_modal();
 				}
 				let dialog = new frappe.ui.Dialog({
-					title: __("Your order {0} has been created", [docname]),
+					title: __("Your order {0} has been created", [this.frm.doc.name]),
 					fields: [
 						{ fieldtype: "HTML", options: `<p>Do you want to create a new order?</p>` }
 					],


### PR DESCRIPTION
fix: order desk pop up message title
![Screenshot from 2020-10-16 17-00-15](https://user-images.githubusercontent.com/51395568/96253406-29468100-0fd1-11eb-8a80-f629196b5b29.png)
