### PR TITLE
fix: check if compliance_item doc exists

### DIFF
--- a/bloomstack_core/patches/v0_0_1/move_compliance_item_to_item.py
+++ b/bloomstack_core/patches/v0_0_1/move_compliance_item_to_item.py
@@ -3,6 +3,9 @@ from frappe.modules.utils import sync_customizations
 
 
 def execute():
+	if not frappe.db.exists("DocType", "Compliance Item"):
+		return
+
 	compliance_items = frappe.get_all("Compliance Item", fields=["*"])
 
 	frappe.reload_doc("stock", "doctype", "item")


### PR DESCRIPTION
fixes: `frappe.exceptions.DoesNotExistError: DocType Compliance Item not found`