### PR TITLE
fix: remove package_tag from search_fields

### DIFF
--- a/bloomstack_core/bloomstack_core/custom/package_tag.json
+++ b/bloomstack_core/bloomstack_core/custom/package_tag.json
@@ -419,7 +419,7 @@
    "parenttype": null,
    "property": "search_fields",
    "property_type": "Data",
-   "value": "item_code,item_name,package_tag,item_group"
+   "value": "item_code,item_name,item_group"
   }
  ],
  "sync_on_migrate": 1


### PR DESCRIPTION
fixes: `frappe.exceptions.ValidationError: Title Field <b>package_tag</b> should not be present in Search Fields.`