### PR TITLE
fix: remove Sales Order naming_series customization

### DIFF
--- a/bloomstack_core/bloomstack_core/custom/sales_order.json
+++ b/bloomstack_core/bloomstack_core/custom/sales_order.json
@@ -376,29 +376,6 @@
    "property": "hidden",
    "property_type": "Check",
    "value": "0"
-  },
-  {
-   "_assign": null,
-   "_comments": null,
-   "_liked_by": null,
-   "_user_tags": null,
-   "creation": "2018-11-28 05:10:51.169484",
-   "default_value": null,
-   "doc_type": "Sales Order",
-   "docstatus": 0,
-   "doctype_or_field": "DocField",
-   "field_name": "naming_series",
-   "idx": 0,
-   "modified": "2018-11-28 05:10:51.169484",
-   "modified_by": "Administrator",
-   "name": "Sales Order-naming_series-options",
-   "owner": "Administrator",
-   "parent": null,
-   "parentfield": null,
-   "parenttype": null,
-   "property": "options",
-   "property_type": "Text",
-   "value": "SAL-ORD-.YYYY.-"
   }
  ],
  "sync_on_migrate": 1


### PR DESCRIPTION
Removed from here as this naming series is already then in core erpnext  https://github.com/Bloomstack/erpnext/blob/production/erpnext/selling/doctype/sales_order/sales_order.json#L179