### PR TITLE
fix: estimate arrival times using google maps

### DIFF
--- a/bloomstack_core/hook_events/delivery_note.py
+++ b/bloomstack_core/hook_events/delivery_note.py
@@ -38,6 +38,11 @@ def execute_bloomtrace_integration_request():
 	for request in pending_requests:
 		integration_request = frappe.get_doc("Integration Request", request.name)
 		delivery_note = frappe.get_doc("Delivery Note", integration_request.reference_docname)
+
+		# If delivery trip is created, only then move forward to integrate with BloomTrace
+		if not delivery_note.lr_no:
+			continue
+
 		try:
 			insert_transfer_template(delivery_note, frappe_client)
 			integration_request.error = ""

--- a/bloomstack_core/hook_events/delivery_note.py
+++ b/bloomstack_core/hook_events/delivery_note.py
@@ -56,6 +56,12 @@ def insert_transfer_template(delivery_note, frappe_client):
 		if stop.delivery_note == delivery_note.name:
 			estimated_arrival = stop.estimated_arrival
 
+	if not estimated_arrival:
+		try:
+			delivery_trip.process_route()
+		except Exception:
+			frappe.throw(_("Estimated Arrival Times are not present."))
+
 	transfer_template_packages = []
 	for item in delivery_note.items:
 		if item.package_tag:


### PR DESCRIPTION
- Since estimated times are not reported to bloomtrace, the METRC Integration breaks
- Sync only those Delivery Notes which has Delivery Trip associated
- Using Google Maps Integration if estimated times are absent
- If Google Maps Integration is disabled, throw an error before syncing with bloomtrace